### PR TITLE
fix parse error when table function has multiple params

### DIFF
--- a/lineage-flink1.16.x/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
+++ b/lineage-flink1.16.x/src/main/java/org/apache/calcite/rel/metadata/RelMdColumnOrigins.java
@@ -113,6 +113,10 @@ public class RelMdColumnOrigins implements MetadataHandler<BuiltInMetadata.Colum
         if (iOutputColumn < nLeftColumns) {
             set = mq.getColumnOrigins(rel.getLeft(), iOutputColumn);
         } else {
+            set = new HashSet<>();
+            for (Integer required : rel.getRequiredColumns().asList()) {
+                set.addAll(mq.getColumnOrigins(rel.getLeft(), required));
+            }
             if (rel.getRight() instanceof TableFunctionScan) {
                 // get the field name of the left table configured in the Table Function on the right
                 TableFunctionScan tableFunctionScan = (TableFunctionScan) rel.getRight();
@@ -121,13 +125,6 @@ public class RelMdColumnOrigins implements MetadataHandler<BuiltInMetadata.Colum
                 RexFieldAccess rexFieldAccess = searchRexFieldAccess(rexCall);
                 if (rexFieldAccess != null) {
                     String fieldName = rexFieldAccess.getField().getName();
-                    /*
-                       Get the fields from the left table, don't go to
-                       getColumnOrigins(TableFunctionScan rel,RelMetadataQuery mq, int iOutputColumn),
-                       otherwise the return is null, and the UDTF field origin cannot be parsed
-                     */
-                    int leftFieldIndex = fieldNameList.indexOf(fieldName);
-                    set = mq.getColumnOrigins(rel.getLeft(), leftFieldIndex);
 
                     // process transform for udtf
                     String transform = rexCall.toString().replace(rexFieldAccess.toString(), fieldName)


### PR DESCRIPTION
1.add   a new column name1 in  dwd_hudi_users and ods_mysql_users
2.then update function 
@FunctionHint(output = @DataTypeHint("ROW<word STRING, length INT>"))
public class MySplitFunction extends TableFunction<Row> {
    public void eval(String str,String str1) {
        for (String s : str.split(" ")) {
            // use collect(...) to emit a row
            collect(Row.of(s, s.length()));
        }
    }
}
3.
String sql = "INSERT INTO dwd_hudi_users " +
                "SELECT " +
                "   length ," +
                "   name ," +
               "   name 1," +
                "   word as company_name ," +
                "   birthday ," +
                "   ts ," +
                "   DATE_FORMAT(birthday, 'yyyyMMdd') " +
                "FROM" +
                "   ods_mysql_users ," +
                "   LATERAL TABLE(my_split_udtf(name,name1))";
